### PR TITLE
adding snowflake mfa with keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.16.0] - 2026-05-19
+### Added
+- RSA keypair authentication support via `private_key_file` and `private_key_content` config options
+- Unified `private_key_passphrase` config option for encrypted keys
+
+### Changed
+- Upgraded `snowflake-connector-python` from `2.7.*` to `3.13.1`
+- Added `cryptography==44.0.1` dependency for key validation and DER conversion
+
+
 1.15.0 (2022-01-14)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,51 @@ Running the the target connector requires a `config.json` file. Example with the
    }
    ```
 
+### Authentication Methods
+
+**Password authentication** (existing):
+```json
+{
+  "account": "rtxxxxx.eu-central-1",
+  "dbname": "database_name",
+  "user": "my_user",
+  "password": "my_password",
+  "warehouse": "my_virtual_warehouse",
+  "file_format": "snowflake_file_format_object_name",
+  "default_target_schema": "my_target_schema"
+}
+```
+
+**Keypair authentication via file path**:
+```json
+{
+  "account": "rtxxxxx.eu-central-1",
+  "dbname": "database_name",
+  "user": "my_user",
+  "private_key_file": "/path/to/rsa_key.p8",
+  "private_key_passphrase": "optional_passphrase_if_encrypted",
+  "warehouse": "my_virtual_warehouse",
+  "file_format": "snowflake_file_format_object_name",
+  "default_target_schema": "my_target_schema"
+}
+```
+
+**Keypair authentication via key content string**:
+```json
+{
+  "account": "rtxxxxx.eu-central-1",
+  "dbname": "database_name",
+  "user": "my_user",
+  "private_key_content": "-----BEGIN PRIVATE KEY-----\n<base64-encoded-key>\n-----END PRIVATE KEY-----",
+  "private_key_passphrase": "optional_passphrase_if_encrypted",
+  "warehouse": "my_virtual_warehouse",
+  "file_format": "snowflake_file_format_object_name",
+  "default_target_schema": "my_target_schema"
+}
+```
+
+Keys must be in PKCS8 PEM format. To convert a PKCS1 key: `openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in key.pem -out key.p8`
+
 Full list of options in `config.json`:
 
 | Property                            | Type    | Required?  | Description                                                   |
@@ -143,7 +188,10 @@ Full list of options in `config.json`:
 | account                             | String  | Yes        | Snowflake account name (i.e. rtXXXXX.eu-central-1)            |
 | dbname                              | String  | Yes        | Snowflake Database name                                       |
 | user                                | String  | Yes        | Snowflake User                                                |
-| password                            | String  | Yes        | Snowflake Password                                            |
+| password                            | String  | Conditional | Snowflake Password. Required if not using keypair authentication. |
+| private_key_file                    | String  | No         | Path to RSA private key file (PKCS8 PEM format). Mutually exclusive with `password` and `private_key_content`. |
+| private_key_content                 | String  | No         | RSA private key as a PEM string (PKCS8 format). Mutually exclusive with `password` and `private_key_file`. |
+| private_key_passphrase              | String  | No         | Passphrase for encrypted private key (used with both `private_key_file` and `private_key_content`). |
 | warehouse                           | String  | Yes        | Snowflake virtual warehouse name                              |
 | role                                | String  | No         | Snowflake role to use. If not defined then the user's default role will be used |
 | aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, `AWS_ACCESS_KEY_ID` environment variable or IAM role will be used |

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="1.15.0",
+      version="1.16.0",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -24,6 +24,7 @@ setup(name="pipelinewise-target-snowflake",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'snowflake-connector-python[pandas]==3.13.1',
+          'cryptography==44.0.1',
           'inflection==0.5.1',
           'joblib==1.2.0',
           'numpy<1.21.0',

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -71,29 +71,36 @@ def validate_config(config):
         if not config.get(k, None):
             errors.append(f"Required key is missing from config: [{k}]")
 
-    # Validate authentication method
+    # Validate authentication method.
+    # Use `is not None` (not bool) so that fields declared with an unset env var
+    # (which resolve to "") are treated as "configured" the same as fields with a
+    # real value. None means the key was never declared in the config at all.
+    configured_password = config.get('password') is not None
+    configured_key_file = config.get('private_key_file') is not None
+    configured_key_content = config.get('private_key_content') is not None
+    configured_passphrase = config.get('private_key_passphrase') is not None
+
+    # has_* mirrors configured_* but only true when value is non-empty (used later
+    # for keypair connection setup and file-existence checks)
     has_password = bool(config.get('password'))
     has_key_file = bool(config.get('private_key_file'))
     has_key_content = bool(config.get('private_key_content'))
-    has_passphrase = bool(config.get('private_key_passphrase'))
 
-    if has_key_file and has_key_content:
-        errors.append("Provide only one of 'private_key_file' or 'private_key_content', not both")
+    if configured_key_file and configured_key_content:
+        errors.append("Configure only one of 'private_key_file' or 'private_key_content', not both")
 
-    auth_methods = [has_password, has_key_file or has_key_content]
-    if sum(auth_methods) == 0:
-        errors.append("Must provide one of: 'password', 'private_key_file', or 'private_key_content'")
-    elif sum(auth_methods) > 1:
-        errors.append("Cannot mix password and keypair authentication. Provide only one method. "
-                      "If you are using environment variables, ensure only the variables for one "
-                      "authentication method are set (e.g. unset SNOWFLAKE_PRIVATE_KEY_FILE / "
-                      "SNOWFLAKE_PRIVATE_KEY_CONTENT when using password authentication)")
+    declared_auth_methods = sum([configured_password, configured_key_file or configured_key_content])
+    if declared_auth_methods == 0:
+        errors.append("Must configure one of: 'password', 'private_key_file', or 'private_key_content'")
+    elif declared_auth_methods > 1:
+        errors.append("Configure only one authentication method: 'password', 'private_key_file', "
+                      "or 'private_key_content'. Remove the unused authentication settings from "
+                      "your configuration even if their environment variables are not exported")
 
-    if has_passphrase and not (has_key_file or has_key_content):
-        errors.append("'private_key_passphrase' is set but neither 'private_key_file' nor "
-                      "'private_key_content' is provided. The passphrase is only used with "
-                      "keypair authentication. Unset 'private_key_passphrase' or provide a "
-                      "private key file/content")
+    if configured_passphrase and not (configured_key_file or configured_key_content):
+        errors.append("'private_key_passphrase' is configured but neither 'private_key_file' nor "
+                      "'private_key_content' is configured. Passphrase is only used with keypair "
+                      "authentication")
 
     if has_key_file and not os.path.exists(config['private_key_file']):
         errors.append(f"Private key file not found: {config['private_key_file']}")

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -71,33 +71,26 @@ def validate_config(config):
         if not config.get(k, None):
             errors.append(f"Required key is missing from config: [{k}]")
 
-    # Validate authentication method.
-    # Use `is not None` so that a field declared in config with an unset env var
-    # (which resolves to "") counts as "configured". None means the key was never
-    # declared in the config at all.
-    configured_password = config.get('password') is not None
-    configured_key_file = config.get('private_key_file') is not None
-    configured_key_content = config.get('private_key_content') is not None
-    configured_passphrase = config.get('private_key_passphrase') is not None
+    # Validate authentication method
+    has_password = bool(config.get('password'))
+    has_key_file = bool(config.get('private_key_file'))
+    has_key_content = bool(config.get('private_key_content'))
+    has_passphrase = bool(config.get('private_key_passphrase'))
 
-    if configured_key_file and configured_key_content:
-        errors.append("Configure only one of 'private_key_file' or 'private_key_content', not both")
+    if has_key_file and has_key_content:
+        errors.append("Provide only one of 'private_key_file' or 'private_key_content', not both")
 
-    declared_auth_methods = sum([configured_password, configured_key_file or configured_key_content])
-    if declared_auth_methods == 0:
-        errors.append("Must configure one of: 'password', 'private_key_file', or 'private_key_content'")
-    elif declared_auth_methods > 1:
-        errors.append("Configure only one authentication method: 'password', 'private_key_file', "
-                      "or 'private_key_content'. Remove the unused authentication settings from "
-                      "your configuration even if their environment variables are not exported")
+    auth_methods = [has_password, has_key_file or has_key_content]
+    if sum(auth_methods) == 0:
+        errors.append("Must provide one of: 'password', 'private_key_file', or 'private_key_content'")
+    elif sum(auth_methods) > 1:
+        errors.append("Cannot mix password and keypair authentication. Provide only one method")
 
-    if configured_passphrase and not (configured_key_file or configured_key_content):
-        errors.append("'private_key_passphrase' is configured but neither 'private_key_file' nor "
-                      "'private_key_content' is configured. Passphrase is only used with keypair "
-                      "authentication")
+    if has_passphrase and not (has_key_file or has_key_content):
+        errors.append("'private_key_passphrase' is set but neither 'private_key_file' nor "
+                      "'private_key_content' is provided. Passphrase is only used with keypair authentication")
 
-    # Use bool() here so os.path.exists is not called with an empty string
-    if bool(config.get('private_key_file')) and not os.path.exists(config['private_key_file']):
+    if has_key_file and not os.path.exists(config['private_key_file']):
         errors.append(f"Private key file not found: {config['private_key_file']}")
 
     # Check target schema config

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -72,19 +72,13 @@ def validate_config(config):
             errors.append(f"Required key is missing from config: [{k}]")
 
     # Validate authentication method.
-    # Use `is not None` (not bool) so that fields declared with an unset env var
-    # (which resolve to "") are treated as "configured" the same as fields with a
-    # real value. None means the key was never declared in the config at all.
+    # Use `is not None` so that a field declared in config with an unset env var
+    # (which resolves to "") counts as "configured". None means the key was never
+    # declared in the config at all.
     configured_password = config.get('password') is not None
     configured_key_file = config.get('private_key_file') is not None
     configured_key_content = config.get('private_key_content') is not None
     configured_passphrase = config.get('private_key_passphrase') is not None
-
-    # has_* mirrors configured_* but only true when value is non-empty (used later
-    # for keypair connection setup and file-existence checks)
-    has_password = bool(config.get('password'))
-    has_key_file = bool(config.get('private_key_file'))
-    has_key_content = bool(config.get('private_key_content'))
 
     if configured_key_file and configured_key_content:
         errors.append("Configure only one of 'private_key_file' or 'private_key_content', not both")
@@ -102,7 +96,8 @@ def validate_config(config):
                       "'private_key_content' is configured. Passphrase is only used with keypair "
                       "authentication")
 
-    if has_key_file and not os.path.exists(config['private_key_file']):
+    # Use bool() here so os.path.exists is not called with an empty string
+    if bool(config.get('private_key_file')) and not os.path.exists(config['private_key_file']):
         errors.append(f"Private key file not found: {config['private_key_file']}")
 
     # Check target schema config

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -1,10 +1,12 @@
 import json
+import os
 import sys
 from typing import List, Dict, Union
 
 import snowflake.connector
 import re
 import time
+from cryptography.hazmat.primitives import serialization
 
 from singer import get_logger
 from target_snowflake import flattening
@@ -24,7 +26,6 @@ def validate_config(config):
         'account',
         'dbname',
         'user',
-        'password',
         'warehouse',
         'azure_storage_account',
         'stage',
@@ -35,7 +36,6 @@ def validate_config(config):
         'account',
         'dbname',
         'user',
-        'password',
         'warehouse',
         's3_bucket',
         'stage',
@@ -46,7 +46,6 @@ def validate_config(config):
         'account',
         'dbname',
         'user',
-        'password',
         'warehouse',
         'file_format'
     ]
@@ -71,6 +70,23 @@ def validate_config(config):
     for k in required_config_keys:
         if not config.get(k, None):
             errors.append(f"Required key is missing from config: [{k}]")
+
+    # Validate authentication method
+    has_password = bool(config.get('password'))
+    has_key_file = bool(config.get('private_key_file'))
+    has_key_content = bool(config.get('private_key_content'))
+
+    if has_key_file and has_key_content:
+        errors.append("Provide only one of 'private_key_file' or 'private_key_content', not both")
+
+    auth_methods = [has_password, has_key_file or has_key_content]
+    if sum(auth_methods) == 0:
+        errors.append("Must provide one of: 'password', 'private_key_file', or 'private_key_content'")
+    elif sum(auth_methods) > 1:
+        errors.append("Cannot mix password and keypair authentication. Provide only one method")
+
+    if has_key_file and not os.path.exists(config['private_key_file']):
+        errors.append(f"Private key file not found: {config['private_key_file']}")
 
     # Check target schema config
     config_default_target_schema = config.get('default_target_schema', None)
@@ -310,15 +326,14 @@ class DbSync:
         if self.stream_schema_message:
             stream = self.stream_schema_message['stream']
 
-        return snowflake.connector.connect(
-            user=self.connection_config['user'],
-            password=self.connection_config['password'],
-            account=self.connection_config['account'],
-            database=self.connection_config['dbname'],
-            warehouse=self.connection_config['warehouse'],
-            role=self.connection_config.get('role', None),
-            autocommit=True,
-            session_parameters={
+        conn_params = {
+            'user': self.connection_config['user'],
+            'account': self.connection_config['account'],
+            'database': self.connection_config['dbname'],
+            'warehouse': self.connection_config['warehouse'],
+            'role': self.connection_config.get('role', None),
+            'autocommit': True,
+            'session_parameters': {
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
                 'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
@@ -326,7 +341,64 @@ class DbSync:
                                               schema=self.schema_name,
                                               table=self.table_name(stream, False, True))
             }
-        )
+        }
+
+        key_file = self.connection_config.get('private_key_file')
+        key_content = self.connection_config.get('private_key_content')
+        passphrase = self.connection_config.get('private_key_passphrase')
+
+        if key_file or key_content:
+            conn_params['authenticator'] = 'SNOWFLAKE_JWT'
+            if key_file:
+                self._validate_private_key_file_permissions(key_file, self.logger)
+                conn_params['private_key_file'] = key_file
+                conn_params['private_key_file_pwd'] = passphrase
+            else:
+                conn_params['private_key'] = self._load_private_key_from_content(key_content, passphrase)
+        else:
+            conn_params['password'] = self.connection_config['password']
+
+        return snowflake.connector.connect(**conn_params)
+
+    def _load_private_key_from_content(self, pem_content, passphrase):
+        """Load PEM key content string, validate, and convert to DER PKCS8 bytes."""
+        try:
+            key_data = pem_content.strip().encode('utf-8')
+
+            if b'BEGIN RSA PRIVATE KEY' in key_data:
+                raise Exception(
+                    "PKCS1 format detected ('BEGIN RSA PRIVATE KEY'). "
+                    "Convert to PKCS8: openssl pkcs8 -topk8 -inform PEM -outform PEM "
+                    "-nocrypt -in key.pem -out key.p8"
+                )
+
+            password = passphrase.encode() if passphrase else None
+            private_key = serialization.load_pem_private_key(key_data, password=password)
+
+            return private_key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption()
+            )
+        except Exception as exc:
+            if 'PKCS1 format detected' in str(exc):
+                raise
+            raise Exception(
+                f"Failed to load private key content. Ensure valid PKCS8 PEM format "
+                f"and correct passphrase. Error: {str(exc)}"
+            ) from exc
+
+    @staticmethod
+    def _validate_private_key_file_permissions(key_file_path, logger):
+        """Warn if private key file has overly permissive permissions."""
+        if os.name != 'nt':
+            file_stat = os.stat(key_file_path)
+            if file_stat.st_mode & 0o077:
+                logger.warning(
+                    "Private key file '%s' has overly permissive permissions. "
+                    "Recommended: chmod 600 or chmod 400",
+                    key_file_path
+                )
 
     def query(self, query: Union[str, List[str]], params: Dict = None, max_records=0) -> List[Dict]:
         """Run an SQL query in snowflake"""

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -75,6 +75,7 @@ def validate_config(config):
     has_password = bool(config.get('password'))
     has_key_file = bool(config.get('private_key_file'))
     has_key_content = bool(config.get('private_key_content'))
+    has_passphrase = bool(config.get('private_key_passphrase'))
 
     if has_key_file and has_key_content:
         errors.append("Provide only one of 'private_key_file' or 'private_key_content', not both")
@@ -83,7 +84,16 @@ def validate_config(config):
     if sum(auth_methods) == 0:
         errors.append("Must provide one of: 'password', 'private_key_file', or 'private_key_content'")
     elif sum(auth_methods) > 1:
-        errors.append("Cannot mix password and keypair authentication. Provide only one method")
+        errors.append("Cannot mix password and keypair authentication. Provide only one method. "
+                      "If you are using environment variables, ensure only the variables for one "
+                      "authentication method are set (e.g. unset SNOWFLAKE_PRIVATE_KEY_FILE / "
+                      "SNOWFLAKE_PRIVATE_KEY_CONTENT when using password authentication)")
+
+    if has_passphrase and not (has_key_file or has_key_content):
+        errors.append("'private_key_passphrase' is set but neither 'private_key_file' nor "
+                      "'private_key_content' is provided. The passphrase is only used with "
+                      "keypair authentication. Unset 'private_key_passphrase' or provide a "
+                      "private key file/content")
 
     if has_key_file and not os.path.exists(config['private_key_file']):
         errors.append(f"Private key file not found: {config['private_key_file']}")
@@ -348,6 +358,8 @@ class DbSync:
         passphrase = self.connection_config.get('private_key_passphrase')
 
         if key_file or key_content:
+            self.logger.info("Connecting to Snowflake using keypair authentication (%s)",
+                             "private_key_file" if key_file else "private_key_content")
             conn_params['authenticator'] = 'SNOWFLAKE_JWT'
             if key_file:
                 self._validate_private_key_file_permissions(key_file, self.logger)
@@ -356,6 +368,7 @@ class DbSync:
             else:
                 conn_params['private_key'] = self._load_private_key_from_content(key_content, passphrase)
         else:
+            self.logger.info("Connecting to Snowflake using password authentication")
             conn_params['password'] = self.connection_config['password']
 
         return snowflake.connector.connect(**conn_params)

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -19,7 +19,14 @@ from target_snowflake.upload_clients.azure_blob_upload_client import AzureBlobUp
 from target_snowflake.upload_clients.snowflake_upload_client import SnowflakeUploadClient
 
 def validate_config(config):
-    """Validate configuration"""
+    """Validate the connector configuration and return a list of error messages.
+
+    Checks staging setup (S3, Azure, or Snowflake table stage), required keys,
+    authentication method, schema config, and archive options.
+
+    Returns an empty list if the config is valid, or a list of error strings
+    that the caller can log and act on.
+    """
     errors = []
 
     azure_storage_required_config_keys = [
@@ -71,25 +78,38 @@ def validate_config(config):
         if not config.get(k, None):
             errors.append(f"Required key is missing from config: [{k}]")
 
-    # Validate authentication method
-    has_password = bool(config.get('password'))
-    has_key_file = bool(config.get('private_key_file'))
-    has_key_content = bool(config.get('private_key_content'))
-    has_passphrase = bool(config.get('private_key_passphrase'))
+    # ── Authentication validation ──────────────────────────────────────────────
+    # Exactly one auth method must be configured: password OR keypair — not both,
+    # not neither. See docs/auth-design-decision.md for the full reasoning.
+    #
+    # Keypair auth accepts two input forms (mutually exclusive):
+    #   private_key_file    — path to a .p8 key file on disk
+    #   private_key_content — the PEM key as an inline string (useful in CI/CD)
 
+    has_password    = bool(config.get('password'))
+    has_key_file    = bool(config.get('private_key_file'))
+    has_key_content = bool(config.get('private_key_content'))
+    has_passphrase  = bool(config.get('private_key_passphrase'))
+
+    # Convenience flag — True when any keypair input form is present
+    using_keypair = has_key_file or has_key_content
+
+    # Rule 1: only one keypair input form may be set at a time
     if has_key_file and has_key_content:
         errors.append("Provide only one of 'private_key_file' or 'private_key_content', not both")
 
-    auth_methods = [has_password, has_key_file or has_key_content]
-    if sum(auth_methods) == 0:
+    # Rule 2: exactly one top-level auth method must be present
+    if not has_password and not using_keypair:
         errors.append("Must provide one of: 'password', 'private_key_file', or 'private_key_content'")
-    elif sum(auth_methods) > 1:
+    elif has_password and using_keypair:
         errors.append("Cannot mix password and keypair authentication. Provide only one method")
 
-    if has_passphrase and not (has_key_file or has_key_content):
+    # Rule 3: a passphrase is only meaningful when a private key is also present
+    if has_passphrase and not using_keypair:
         errors.append("'private_key_passphrase' is set but neither 'private_key_file' nor "
                       "'private_key_content' is provided. Passphrase is only used with keypair authentication")
 
+    # Rule 4: if a key file path is given, it must exist on disk
     if has_key_file and not os.path.exists(config['private_key_file']):
         errors.append(f"Private key file not found: {config['private_key_file']}")
 
@@ -326,7 +346,12 @@ class DbSync:
             self.upload_client = SnowflakeUploadClient(connection_config, self)
 
     def open_connection(self):
-        """Open snowflake connection"""
+        """Open and return a Snowflake connection using the configured auth method.
+
+        The auth method (keypair or password) is resolved from connection_config.
+        validate_config() guarantees exactly one method is present before this is called,
+        so the if/else below is a branch on known state — not a runtime fallback.
+        """
         stream = None
         if self.stream_schema_message:
             stream = self.stream_schema_message['stream']
@@ -348,31 +373,55 @@ class DbSync:
             }
         }
 
-        key_file = self.connection_config.get('private_key_file')
+        key_file   = self.connection_config.get('private_key_file')
         key_content = self.connection_config.get('private_key_content')
-        passphrase = self.connection_config.get('private_key_passphrase')
+        passphrase  = self.connection_config.get('private_key_passphrase')
 
         if key_file or key_content:
+            # Keypair authentication (recommended — Snowflake deprecates password auth Aug 2026)
             self.logger.info("Connecting to Snowflake using keypair authentication (%s)",
                              "private_key_file" if key_file else "private_key_content")
             conn_params['authenticator'] = 'SNOWFLAKE_JWT'
+
             if key_file:
+                # Key supplied as a file path — pass it directly to the connector
                 self._validate_private_key_file_permissions(key_file, self.logger)
-                conn_params['private_key_file'] = key_file
+                conn_params['private_key_file']     = key_file
                 conn_params['private_key_file_pwd'] = passphrase
             else:
+                # Key supplied as inline PEM content — load and convert to DER bytes
                 conn_params['private_key'] = self._load_private_key_from_content(key_content, passphrase)
+
         else:
+            # Password authentication — validate_config confirmed this is the only method set.
+            # Note: Snowflake is deprecating password auth on August 31, 2026.
             self.logger.info("Connecting to Snowflake using password authentication")
             conn_params['password'] = self.connection_config['password']
 
         return snowflake.connector.connect(**conn_params)
 
     def _load_private_key_from_content(self, pem_content, passphrase):
-        """Load PEM key content string, validate, and convert to DER PKCS8 bytes."""
+        """Load a PEM private key from an inline string and return it as DER-encoded PKCS8 bytes.
+
+        The Snowflake Python connector expects the private_key parameter in DER/PKCS8 format,
+        so this method handles the conversion. Only PKCS8 PEM keys are accepted
+        ('BEGIN PRIVATE KEY'). PKCS1 keys ('BEGIN RSA PRIVATE KEY') are rejected with a
+        clear conversion hint.
+
+        Args:
+            pem_content: The private key as a PEM-formatted string.
+            passphrase:  Optional passphrase to decrypt the key, or None if unencrypted.
+
+        Returns:
+            DER-encoded PKCS8 bytes suitable for snowflake.connector.connect(private_key=...).
+
+        Raises:
+            Exception: If the key format is PKCS1, the passphrase is wrong, or the PEM is invalid.
+        """
         try:
             key_data = pem_content.strip().encode('utf-8')
 
+            # Snowflake requires PKCS8 format. Catch PKCS1 early and give a clear fix hint.
             if b'BEGIN RSA PRIVATE KEY' in key_data:
                 raise Exception(
                     "PKCS1 format detected ('BEGIN RSA PRIVATE KEY'). "
@@ -383,6 +432,7 @@ class DbSync:
             password = passphrase.encode() if passphrase else None
             private_key = serialization.load_pem_private_key(key_data, password=password)
 
+            # Return as unencrypted DER bytes — the connector handles it from here
             return private_key.private_bytes(
                 encoding=serialization.Encoding.DER,
                 format=serialization.PrivateFormat.PKCS8,
@@ -398,10 +448,15 @@ class DbSync:
 
     @staticmethod
     def _validate_private_key_file_permissions(key_file_path, logger):
-        """Warn if private key file has overly permissive permissions."""
+        """Warn if the private key file is readable by group or others.
+
+        Checks are skipped on Windows (os.name == 'nt') as POSIX permission
+        bits do not apply there. On Unix systems, a key file should be
+        accessible only by the owner (chmod 600 or 400).
+        """
         if os.name != 'nt':
             file_stat = os.stat(key_file_path)
-            if file_stat.st_mode & 0o077:
+            if file_stat.st_mode & 0o077:  # any group or other permission bits set
                 logger.warning(
                     "Private key file '%s' has overly permissive permissions. "
                     "Recommended: chmod 600 or chmod 400",

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -350,7 +350,7 @@ class TestDBSync(unittest.TestCase):
             'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
         }
         errors = validator(config)
-        self.assertTrue(any('Cannot mix' in e for e in errors))
+        self.assertTrue(any('Configure only one' in e for e in errors))
 
     def test_config_validation_rejects_both_key_sources(self):
         """Test config validation rejects file + content together"""
@@ -363,7 +363,7 @@ class TestDBSync(unittest.TestCase):
             'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
         }
         errors = validator(config)
-        self.assertTrue(any("only one" in e.lower() for e in errors))
+        self.assertTrue(any('only one' in e.lower() for e in errors))
 
     def test_config_validation_rejects_no_auth(self):
         """Test config validation rejects missing auth entirely"""
@@ -374,7 +374,61 @@ class TestDBSync(unittest.TestCase):
             'default_target_schema': 'dummy'
         }
         errors = validator(config)
-        self.assertTrue(any('Must provide' in e for e in errors))
+        self.assertTrue(any('Must configure' in e for e in errors))
+
+    def test_config_validation_rejects_all_auth_fields_as_empty_strings(self):
+        """All four auth fields declared with empty strings (unset env vars) must error"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': '',
+            'private_key_file': '',
+            'private_key_content': '',
+            'private_key_passphrase': '',
+        }
+        errors = validator(config)
+        self.assertTrue(any('Configure only one' in e for e in errors))
+
+    def test_config_validation_rejects_password_and_empty_key_file(self):
+        """password (real value) + private_key_file (empty string) must error"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': 'secret',
+            'private_key_file': '',
+        }
+        errors = validator(config)
+        self.assertTrue(any('Configure only one' in e for e in errors))
+
+    def test_config_validation_rejects_password_and_empty_key_content(self):
+        """password (real value) + private_key_content (empty string) must error"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': 'secret',
+            'private_key_content': '',
+        }
+        errors = validator(config)
+        self.assertTrue(any('Configure only one' in e for e in errors))
+
+    def test_config_validation_rejects_passphrase_without_key(self):
+        """private_key_passphrase configured without any key method must error"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': 'secret',
+            'private_key_passphrase': 'pp',
+        }
+        errors = validator(config)
+        self.assertTrue(any('passphrase' in e.lower() for e in errors))
 
     @patch('target_snowflake.db_sync.DbSync.query')
     def test_open_connection_with_keypair_content(self, query_patch):

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -312,3 +312,106 @@ class TestDBSync(unittest.TestCase):
         with self.assertRaisesRegex(PrimaryKeyNotFoundException,
                                     "Cannot find \['invalid_col'\] primary key\(s\) in record\. Available fields: \['id', 'c_str'\]"):
             dbsync.record_primary_key_string({'id': 123, 'c_str': 'xyz'})
+
+    def test_config_validation_keypair_file(self):
+        """Test config validation accepts keypair file auth"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_file': '/tmp/test_key_nonexistent.pem'
+        }
+        errors = validator(config)
+        # Only the file-not-found error should be present; no password-related error
+        self.assertTrue(any('not found' in e for e in errors))
+        self.assertFalse(any('password' in e.lower() for e in errors))
+
+    def test_config_validation_keypair_content(self):
+        """Test config validation accepts keypair content auth"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
+        }
+        errors = validator(config)
+        self.assertEqual(len(errors), 0)
+
+    def test_config_validation_rejects_mixed_auth(self):
+        """Test config validation rejects password + keypair together"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': 'secret',
+            'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
+        }
+        errors = validator(config)
+        self.assertTrue(any('Cannot mix' in e for e in errors))
+
+    def test_config_validation_rejects_both_key_sources(self):
+        """Test config validation rejects file + content together"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_file': '/tmp/key.pem',
+            'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
+        }
+        errors = validator(config)
+        self.assertTrue(any("only one" in e.lower() for e in errors))
+
+    def test_config_validation_rejects_no_auth(self):
+        """Test config validation rejects missing auth entirely"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy'
+        }
+        errors = validator(config)
+        self.assertTrue(any('Must provide' in e for e in errors))
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_open_connection_with_keypair_content(self, query_patch):
+        """Test that _load_private_key_from_content returns valid DER bytes"""
+        query_patch.return_value = [{'type': 'CSV'}]
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives import serialization as crypto_serialization
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            crypto_serialization.Encoding.PEM,
+            crypto_serialization.PrivateFormat.PKCS8,
+            crypto_serialization.NoEncryption()
+        ).decode()
+
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_content': pem
+        }
+        dbsync = db_sync.DbSync(config)
+        der_bytes = dbsync._load_private_key_from_content(pem, None)
+        self.assertIsInstance(der_bytes, bytes)
+        self.assertGreater(len(der_bytes), 0)
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_load_private_key_rejects_pkcs1(self, query_patch):
+        """Test that PKCS1 format keys are rejected with a helpful message"""
+        query_patch.return_value = [{'type': 'CSV'}]
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_content': '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----'
+        }
+        dbsync = db_sync.DbSync(config)
+        with self.assertRaises(Exception) as ctx:
+            dbsync._load_private_key_from_content(config['private_key_content'], None)
+        self.assertIn('PKCS1', str(ctx.exception))

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -350,7 +350,7 @@ class TestDBSync(unittest.TestCase):
             'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----'
         }
         errors = validator(config)
-        self.assertTrue(any('Configure only one' in e for e in errors))
+        self.assertTrue(any('Cannot mix' in e for e in errors))
 
     def test_config_validation_rejects_both_key_sources(self):
         """Test config validation rejects file + content together"""
@@ -374,61 +374,65 @@ class TestDBSync(unittest.TestCase):
             'default_target_schema': 'dummy'
         }
         errors = validator(config)
-        self.assertTrue(any('Must configure' in e for e in errors))
-
-    def test_config_validation_rejects_all_auth_fields_as_empty_strings(self):
-        """All four auth fields declared with empty strings (unset env vars) must error"""
-        validator = db_sync.validate_config
-        config = {
-            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
-            'warehouse': 'dummy', 'file_format': 'dummy',
-            'default_target_schema': 'dummy',
-            'password': '',
-            'private_key_file': '',
-            'private_key_content': '',
-            'private_key_passphrase': '',
-        }
-        errors = validator(config)
-        self.assertTrue(any('Configure only one' in e for e in errors))
-
-    def test_config_validation_rejects_password_and_empty_key_file(self):
-        """password (real value) + private_key_file (empty string) must error"""
-        validator = db_sync.validate_config
-        config = {
-            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
-            'warehouse': 'dummy', 'file_format': 'dummy',
-            'default_target_schema': 'dummy',
-            'password': 'secret',
-            'private_key_file': '',
-        }
-        errors = validator(config)
-        self.assertTrue(any('Configure only one' in e for e in errors))
-
-    def test_config_validation_rejects_password_and_empty_key_content(self):
-        """password (real value) + private_key_content (empty string) must error"""
-        validator = db_sync.validate_config
-        config = {
-            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
-            'warehouse': 'dummy', 'file_format': 'dummy',
-            'default_target_schema': 'dummy',
-            'password': 'secret',
-            'private_key_content': '',
-        }
-        errors = validator(config)
-        self.assertTrue(any('Configure only one' in e for e in errors))
+        self.assertTrue(any('Must provide' in e for e in errors))
 
     def test_config_validation_rejects_passphrase_without_key(self):
-        """private_key_passphrase configured without any key method must error"""
+        """private_key_passphrase set without any key method must error"""
         validator = db_sync.validate_config
         config = {
             'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
             'warehouse': 'dummy', 'file_format': 'dummy',
             'default_target_schema': 'dummy',
             'password': 'secret',
-            'private_key_passphrase': 'pp',
+            'private_key_passphrase': 'passphrase',
         }
         errors = validator(config)
         self.assertTrue(any('passphrase' in e.lower() for e in errors))
+
+    def test_config_validation_rejects_password_and_key_file(self):
+        """password + private_key_file together must error"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'password': 'secret',
+            'private_key_file': '/tmp/key.pem',
+        }
+        errors = validator(config)
+        self.assertTrue(any('Cannot mix' in e for e in errors))
+
+    def test_config_validation_keypair_file_with_passphrase(self):
+        """private_key_file + passphrase is valid (encrypted key file)"""
+        import tempfile, os
+        validator = db_sync.validate_config
+        tmp = tempfile.NamedTemporaryFile(suffix='.pem', delete=False)
+        tmp.close()
+        try:
+            config = {
+                'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+                'warehouse': 'dummy', 'file_format': 'dummy',
+                'default_target_schema': 'dummy',
+                'private_key_file': tmp.name,
+                'private_key_passphrase': 'mypassphrase',
+            }
+            errors = validator(config)
+            self.assertEqual(len(errors), 0)
+        finally:
+            os.unlink(tmp.name)
+
+    def test_config_validation_keypair_content_with_passphrase(self):
+        """private_key_content + passphrase is valid (encrypted key content)"""
+        validator = db_sync.validate_config
+        config = {
+            'account': 'dummy', 'dbname': 'dummy', 'user': 'dummy',
+            'warehouse': 'dummy', 'file_format': 'dummy',
+            'default_target_schema': 'dummy',
+            'private_key_content': '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----',
+            'private_key_passphrase': 'mypassphrase',
+        }
+        errors = validator(config)
+        self.assertEqual(len(errors), 0)
 
     @patch('target_snowflake.db_sync.DbSync.query')
     def test_open_connection_with_keypair_content(self, query_patch):


### PR DESCRIPTION
## Problem
This pull request introduces support for RSA keypair authentication in addition to password authentication for connecting to Snowflake. It adds new configuration options for specifying the private key either as a file or as a string, updates validation logic to ensure proper and exclusive use of authentication methods, and enhances documentation and tests to cover these new features. The Snowflake connector and cryptography dependencies are also updated to support these changes.

**Authentication Improvements:**
- Added support for RSA keypair authentication using `private_key_file` or `private_key_content` config options, along with a unified `private_key_passphrase` option for encrypted keys. The connection logic in `DbSync.open_connection` now handles both password and keypair authentication, including loading and validating PEM/DER keys and checking file permissions.
- Updated configuration validation to enforce that only one authentication method is used (password or keypair), checks for mutual exclusivity of key sources, and provides clear error messages for misconfiguration.

**Documentation Updates:**
- Expanded the `README.md` with detailed examples for password and both keypair authentication methods, including usage notes and conversion instructions for key formats. The configuration options table now documents the new fields and their requirements.
- Updated the `CHANGELOG.md` to reflect the new authentication features, dependency changes, and connector upgrades.

**Dependency and Version Bumps:**
- Upgraded `snowflake-connector-python` to version `3.13.1` and added `cryptography==44.0.1` as a required dependency for key validation and conversion. Bumped the package version to `1.16.0`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L9-R9) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R27)

**Testing Enhancements:**
- Added unit tests to validate the new authentication logic, including acceptance and rejection of various config combinations, proper handling of PKCS8 and PKCS1 key formats, and key loading functionality.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions